### PR TITLE
Potential fix for code scanning alert no. 43: Server-side request forgery

### DIFF
--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -11,11 +11,20 @@ import { UserModel } from '../models/user'
 import * as utils from '../lib/utils'
 const security = require('../lib/insecurity')
 const request = require('request')
-
+import { URL } from 'url'
 module.exports = function profileImageUrlUpload () {
   return (req: Request, res: Response, next: NextFunction) => {
     if (req.body.imageUrl !== undefined) {
       const url = req.body.imageUrl
+      const allowedDomains = ['example.com', 'another-example.com']
+      try {
+        const parsedUrl = new URL(url)
+        if (!allowedDomains.includes(parsedUrl.hostname)) {
+          throw new Error('Invalid domain')
+        }
+      } catch (err) {
+        return next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
+      }
       if (url.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {


### PR DESCRIPTION
Potential fix for [https://github.com/seshgirik/juice-shop/security/code-scanning/43](https://github.com/seshgirik/juice-shop/security/code-scanning/43)

To fix the SSRF vulnerability, we need to ensure that the user-provided URL is validated and restricted to a set of allowed domains or paths. This can be achieved by implementing a whitelist of allowed domains and checking the user-provided URL against this list before making the request.

1. Create a whitelist of allowed domains.
2. Parse the user-provided URL and extract the hostname.
3. Check if the hostname is in the whitelist.
4. If the hostname is not in the whitelist, reject the request or handle it appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
