### PR TITLE
Potential fix for code scanning alert no. 34: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,8 @@
     "web3": "^4.0.3",
     "winston": "^3.3.3",
     "yaml-schema-validator": "^1.2.2",
-    "z85": "^0.0.2"
+    "z85": "^0.0.2",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@cyclonedx/cyclonedx-npm": "^1.12.0",

--- a/server.ts
+++ b/server.ts
@@ -23,6 +23,7 @@ import { WalletModel } from './models/wallet'
 import logger from './lib/logger'
 import config from 'config'
 import path from 'path'
+import lusca from 'lusca'
 import morgan from 'morgan'
 import colors from 'colors/safe'
 import * as utils from './lib/utils'
@@ -278,6 +279,7 @@ restoreOverwrittenFilesWithOriginals().then(() => {
 
   app.use(express.static(path.resolve('frontend/dist/frontend')))
   app.use(cookieParser('kekse'))
+  app.use(lusca.csrf())
   // vuln-code-snippet end directoryListingChallenge accessLogDisclosureChallenge
 
   /* Configure and enable backend-side i18n */


### PR DESCRIPTION
Potential fix for [https://github.com/seshgirik/juice-shop/security/code-scanning/34](https://github.com/seshgirik/juice-shop/security/code-scanning/34)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package provides a CSRF middleware that can be easily integrated into the application. We will install the `lusca` package and then add the CSRF middleware to the Express app configuration.

1. Install the `lusca` package.
2. Import the `lusca` package in the `server.ts` file.
3. Add the CSRF middleware to the Express app configuration after the `cookieParser` middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
